### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ $ curl "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" | sudo
 $ wc -l /etc/hosts
 31998
 
-$ egrep -ve "^#|^255.255.255|^0.0.0.0|^127.0.0.0|^0 " /etc/hosts
+$ egrep -ve "^#|^255.255.255|^0.0.0.0|^127.0.0.1|^0 " /etc/hosts
 ::1 localhost
 fe80::1%lo0 localhost
 [should not return any other IP addresses]


### PR DESCRIPTION
The current command 
```
 $egrep -ve "^#|^255.255.255|^0.0.0.0|^127.0.0.0|^0 " /etc/hosts

```
returns the following:

```

127.0.0.1 localhost
127.0.0.1 localhost.localdomain
127.0.0.1 local
::1 localhost
fe80::1%lo0 localhost

```

While this doesn't affect security in any way, it can be confusing to someone who is following the guide and expecting to see 

```
::1 localhost
fe80::1%lo0 localhost

```

Thus, to prevent confusion the command should read 

```

egrep -ve "^#|^255.255.255|^0.0.0.0|^127.0.0.1|^0 " /etc/hosts